### PR TITLE
add two annotation mapping csv

### DIFF
--- a/annotation_maps/biospecimenType-BRENDA.csv
+++ b/annotation_maps/biospecimenType-BRENDA.csv
@@ -1,0 +1,18 @@
+biospecimenType,BRENDA
+PBMCs,BTO_0001025
+kidney biopsy,BTO_0000671
+none,
+plasma,BTO_0000131
+saliva,BTO_0001202
+salivary gland,BTO_0001203
+serum,BTO_0000133
+skin biopsy,BTO_0001253
+skin swab,
+stool,BTO_0000440
+suction blister cells,
+suction blister fluid,
+synovial fluid,BTO_0001339
+synovial tissue,BTO_0001823
+total leukocytes,BTO_0000751
+urine,BTO_0001419
+uvea,

--- a/annotation_maps/diagnosis-DOID.csv
+++ b/annotation_maps/diagnosis-DOID.csv
@@ -1,0 +1,12 @@
+diagnosisAbbreviation,diagnosis,DOID
+RA,rheumatoid arthritis,DOID:7148
+SLE,systemic lupus erythematosus,DOID:9074
+PsA,psoriatic arthritis,DOID:9008
+PsO,psoriasis,DOID:8893
+V,vitiligo,DOID:12306
+DM,dermatomyositis,DOID:10223
+Sc,scleroderma,DOID:419
+SjD,Sjogren's syndrome,DOID:12894
+LN,lupus nephritis,DOID:0080162
+CLE,cutaneous lupus erythematosus,DOID:0050169
+Ctrl,control,


### PR DESCRIPTION
to streamline addition of `BRENDA` and `DOID` as annotations in biospecimen and clinical metadata files, respectively. Code can then read in these csv programmatically to perform joins to add these columns to these tables. Contributes to #26 